### PR TITLE
add caching for settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ Features.defined_features
 Settings.defined_settings
 ```
 
+Cache settings:
+
+```ruby
+Settings.cache_settings!
+```
+Note that a simple call to `Settings.init_settings!` will remove caching.
+
 You can create as many Setting or Feature classes as you desire. Here are some examples:
 
 ```ruby

--- a/lib/feature_setting/orm/active_record/fs_feature.rb
+++ b/lib/feature_setting/orm/active_record/fs_feature.rb
@@ -48,6 +48,10 @@ module FeatureSetting
         remove_old_features! if remove_old_features
       end
 
+      def cache_features!
+        # that's a noop so far.
+      end
+
       def remove_old_features!
         self.where(key: all_stored_features - defined_features).destroy_all
       end

--- a/lib/generators/feature_setting/install/templates/migrations/create_fs_tables.rb
+++ b/lib/generators/feature_setting/install/templates/migrations/create_fs_tables.rb
@@ -1,4 +1,4 @@
-class CreateFsTables < ActiveRecord::Migration
+class CreateFsTables < ActiveRecord::Migration[4.2]
   def self.up
     create_table :fs_features do |t|
       t.string :key
@@ -14,5 +14,10 @@ class CreateFsTables < ActiveRecord::Migration
       t.string :klass
       t.timestamps null: false
     end
+  end
+
+  def self.down
+    drop_table :fs_features
+    drop_table :fs_settings
   end
 end

--- a/spec/models/fs_feature_spec.rb
+++ b/spec/models/fs_feature_spec.rb
@@ -2,11 +2,18 @@ require 'spec_helper'
 
 RSpec.describe FeatureSetting::FsFeature, type: :model do
   # using identical FeatureSetting::Feature class
-  let(:fsf) { FeatureSetting::Feature }
+  let(:fsf) do
+    class TestFeature < FeatureSetting::FsFeature
+      FEATURES = {
+        test: false,
+        authentication: true
+      }
+    end
+    TestFeature
+  end
 
   describe 'class methods' do
     before do
-      stub_const('FeatureSetting::FsFeature::FEATURES', test: false, authentication: true)
       fsf.init_features!
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,6 @@
 require 'bundler/setup'
-require 'codeclimate-test-reporter'
-CodeClimate::TestReporter.start
+#require 'codeclimate-test-reporter'
+#CodeClimate::TestReporter.start
 Bundler.setup
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 
@@ -11,7 +11,7 @@ require 'generators/feature_setting/install/templates/migrations/create_fs_table
 
 ActiveRecord::Base.establish_connection(
   adapter: 'sqlite3',
-  database: 'file::memory:?cache=shared'
+  database: ':memory:'
 )
 ActiveRecord::Base.logger = Logger.new(STDOUT)
 CreateFsTables.up


### PR DESCRIPTION
- make sqlite in-memory DB work with activerecord 5
- fix the specs (had to remove stub_const)
- add caching for settings

Activate by

```
MyClassThatDerivesFromFsSetting.cache_settings!
```