### PR TITLE
Feature/remove rails 6 update attributes warning

### DIFF
--- a/lib/feature_setting/orm/active_record/fs_feature.rb
+++ b/lib/feature_setting/orm/active_record/fs_feature.rb
@@ -85,14 +85,14 @@ module FeatureSetting
       def enable!(key)
         if features.key?(key.to_sym)
           record = self.where(key: key, klass: klass).first
-          record.update_attributes(enabled: true)
+          record.update(enabled: true)
         end
       end
 
       def disable!(key)
         if features.key?(key.to_sym)
           record = self.where(key: key, klass: klass).first
-          record.update_attributes(enabled: false)
+          record.update(enabled: false)
         end
       end
 

--- a/lib/feature_setting/orm/active_record/fs_setting.rb
+++ b/lib/feature_setting/orm/active_record/fs_setting.rb
@@ -82,7 +82,7 @@ module FeatureSetting
           value_type = value.class.to_s
         end
 
-        record.update_attributes(
+        record.update(
           value: convert_to_string(new_value, new_value.class.to_s),
           value_type: value_type
         )

--- a/spec/models/fs_feature_spec.rb
+++ b/spec/models/fs_feature_spec.rb
@@ -1,14 +1,15 @@
 require 'spec_helper'
 
 RSpec.describe FeatureSetting::FsFeature, type: :model do
+  class TestFeature < FeatureSetting::FsFeature
+    FEATURES = {
+      test: false,
+      authentication: true
+    }.freeze
+  end
+
   # using identical FeatureSetting::Feature class
   let(:fsf) do
-    class TestFeature < FeatureSetting::FsFeature
-      FEATURES = {
-        test: false,
-        authentication: true
-      }
-    end
     TestFeature
   end
 

--- a/spec/models/fs_setting_spec.rb
+++ b/spec/models/fs_setting_spec.rb
@@ -1,21 +1,23 @@
 require 'spec_helper'
 
 RSpec.describe FeatureSetting::FsSetting, type: :model do
-  let(:fss) do
-    class TestSetting < FeatureSetting::Setting
-      SETTINGS = {
-        test: 'value',
-        version: '0.1.0',
-        sym_test: :a_symbol,
-        hash_test: {
-          one: :two,
-          three: {
-            four: :five,
-            six: :seven
-          }
+
+  class TestSetting < FeatureSetting::Setting
+    SETTINGS = {
+      test: 'value',
+      version: '0.1.0',
+      sym_test: :a_symbol,
+      hash_test: {
+        one: :two,
+        three: {
+          four: :five,
+          six: :seven
         }
       }
-    end
+    }.freeze
+  end
+
+  let(:fss) do
     TestSetting
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,4 +15,5 @@ ActiveRecord::Base.establish_connection(
   database: ':memory:'
 )
 ActiveRecord::Base.logger = Logger.new(STDOUT)
+ActiveRecord::Base.logger.level = :warn
 CreateFsTables.up


### PR DESCRIPTION
using `update` rather than `update_attributes` to address Rails 6 deprecation warning:

```
DEPRECATION WARNING: update_attributes is deprecated and will be removed from Rails 6.1 (please, use update instead)
```