### PR TITLE
<feature>_enabled? will fallback to false when feature record is deleted after initialization

### DIFF
--- a/lib/feature_setting/orm/active_record/fs_feature.rb
+++ b/lib/feature_setting/orm/active_record/fs_feature.rb
@@ -54,7 +54,7 @@ module FeatureSetting
       def define_checker_method(key, &block)
         block = Proc.new do
           record = self.where(key: key, klass: klass).first
-          record.enabled
+          record ? record.enabled : false
         end unless block_given?
         define_singleton_method("#{key}_enabled?") { block.call }
       end

--- a/spec/models/fs_feature_spec.rb
+++ b/spec/models/fs_feature_spec.rb
@@ -80,6 +80,13 @@ RSpec.describe FeatureSetting::FsFeature, type: :model do
       it 'creates enabled? methods' do
         expect(fsf.test_enabled?).to be_falsey
       end
+
+      it 'returns false when feature is deleted after initialization' do
+        fsf.enable_test!
+        expect(fsf.test_enabled?).to be_truthy
+        fsf.where(key: 'test').first.destroy
+        expect(fsf.test_enabled?).to be_falsey
+      end
     end
 
     describe '.enable!' do


### PR DESCRIPTION
with cached classes in staging:
```ruby
Rails.application.configure do
  # Code is not reloaded between requests.
  config.cache_classes = true
...
```

we experience issues when we load a feature set from a fixture not mapping completely what is defined in the feature class. When checking for features with `<feature>_enabled?` this will cause a raise due to 

> undefined method `enabled' for nil:NilClass

This PR adds and additional check for record presence and will return `false` like it would for unknown features (due to method missing) 