### PR TITLE
Refactoring, cleanup and tests

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,100 @@
+require:
+  - rubocop-rake
+  - rubocop-rspec
+
+AllCops:
+  TargetRubyVersion: 2.6
+Style/FrozenStringLiteralComment:
+  Enabled: false
+Metrics/BlockLength:
+  Exclude:
+    - 'spec/**/*'
+    - 'feature_setting.gemspec'
+RSpec/MultipleExpectations:
+  Max: 3
+RSpec/ExampleLength:
+  Max: 10
+RSpec/MessageSpies:
+  EnforcedStyle: receive
+Style/Documentation:
+  Enabled: false
+Metrics/ClassLength:
+  Max: 105
+Metrics/MethodLength:
+  Max: 12
+  Exclude:
+    - 'lib/generators/**/**'
+RSpec/FilePath:
+  Enabled: false
+Gemspec/DateAssignment: # (new in 1.10)
+  Enabled: true
+Layout/SpaceBeforeBrackets: # (new in 1.7)
+  Enabled: true
+Lint/AmbiguousAssignment: # (new in 1.7)
+  Enabled: true
+Lint/DeprecatedConstants: # (new in 1.8)
+  Enabled: true
+Lint/DuplicateBranch: # (new in 1.3)
+  Enabled: true
+Lint/DuplicateRegexpCharacterClassElement: # (new in 1.1)
+  Enabled: true
+Lint/EmptyBlock: # (new in 1.1)
+  Enabled: true
+Lint/EmptyClass: # (new in 1.3)
+  Enabled: true
+Lint/EmptyInPattern: # (new in 1.16)
+  Enabled: true
+Lint/LambdaWithoutLiteralBlock: # (new in 1.8)
+  Enabled: true
+Lint/NoReturnInBeginEndBlocks: # (new in 1.2)
+  Enabled: true
+Lint/NumberedParameterAssignment: # (new in 1.9)
+  Enabled: true
+Lint/OrAssignmentToConstant: # (new in 1.9)
+  Enabled: true
+Lint/RedundantDirGlobSort: # (new in 1.8)
+  Enabled: true
+Lint/SymbolConversion: # (new in 1.9)
+  Enabled: true
+Lint/ToEnumArguments: # (new in 1.1)
+  Enabled: true
+Lint/TripleQuotes: # (new in 1.9)
+  Enabled: true
+Lint/UnexpectedBlockArity: # (new in 1.5)
+  Enabled: true
+Lint/UnmodifiedReduceAccumulator: # (new in 1.1)
+  Enabled: true
+Style/ArgumentsForwarding: # (new in 1.1)
+  Enabled: true
+Style/CollectionCompact: # (new in 1.2)
+  Enabled: true
+Style/DocumentDynamicEvalDefinition: # (new in 1.1)
+  Enabled: true
+Style/EndlessMethod: # (new in 1.8)
+  Enabled: true
+Style/HashConversion: # (new in 1.10)
+  Enabled: true
+Style/HashExcept: # (new in 1.7)
+  Enabled: true
+Style/IfWithBooleanLiteralBranches: # (new in 1.9)
+  Enabled: true
+Style/InPatternThen: # (new in 1.16)
+  Enabled: true
+Style/MultilineInPatternThen: # (new in 1.16)
+  Enabled: true
+Style/NegatedIfElseCondition: # (new in 1.2)
+  Enabled: true
+Style/NilLambda: # (new in 1.3)
+  Enabled: true
+Style/QuotedSymbols: # (new in 1.16)
+  Enabled: true
+Style/RedundantArgument: # (new in 1.4)
+  Enabled: true
+Style/StringChars: # (new in 1.12)
+  Enabled: true
+Style/SwapValues: # (new in 1.1)
+  Enabled: true
+RSpec/IdenticalEqualityAssertion: # (new in 2.4)
+  Enabled: true
+RSpec/Rails/AvoidSetupHook: # (new in 2.4)
+  Enabled: true

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,1 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
-require "bundler/setup"
-require "feature_setting"
+require 'bundler/setup'
+require 'feature_setting'
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.
@@ -10,5 +10,5 @@ require "feature_setting"
 # require "pry"
 # Pry.start
 
-require "irb"
+require 'irb'
 IRB.start

--- a/feature_setting.gemspec
+++ b/feature_setting.gemspec
@@ -1,29 +1,36 @@
-# coding: utf-8
-lib = File.expand_path('../lib', __FILE__)
+lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'feature_setting/version'
 
 Gem::Specification.new do |spec|
-  spec.name          = 'feature_setting'
-  spec.version       = FeatureSetting::VERSION
-  spec.licenses      = ['MIT']
-  spec.authors       = ['Indro De']
-  spec.email         = ['indro.de@gmail.com']
+  spec.required_ruby_version = '>= 2.6.0'
+  spec.name                  = 'feature_setting'
+  spec.version               = FeatureSetting::VERSION
+  spec.licenses              = ['MIT']
+  spec.authors               = ['Indro De']
+  spec.email                 = ['indro.de@gmail.com']
 
-  spec.summary       = 'A lightweight feature/setting DSL for Rails applications.'
-  spec.description   = 'This gem introduces the concept of "features" and "settings" to your Rails app. It provides an easy way to define such features and settings with default values right in your code and will persist them in the database.'
-  spec.homepage      = 'https://github.com/indrode/feature_setting'
+  spec.summary               = 'A lightweight feature/setting DSL for Rails applications.'
+  spec.description           = <<-DESCRIPTION
+    This gem introduces the concept of "features" and "settings" to your Rails app.
+    It provides an easy way to define such features and settings with default values
+    right in your code and will persist them in the database.
+  DESCRIPTION
+  spec.homepage              = 'https://github.com/indrode/feature_setting'
 
-  spec.files         = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
-  spec.require_paths = ['lib']
+  spec.files                 = `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
+  spec.require_paths         = ['lib']
 
-  spec.add_runtime_dependency 'activesupport', '>= 4.0'
   spec.add_runtime_dependency 'activerecord', '>= 4.0'
+  spec.add_runtime_dependency 'activesupport', '>= 4.0'
   spec.add_runtime_dependency 'hashie', '>= 3.4.3'
   spec.add_development_dependency 'bundler', '>= 1.9'
+  spec.add_development_dependency 'byebug'
   spec.add_development_dependency 'rake', '>= 10.0'
   spec.add_development_dependency 'rspec', '>= 3.0'
-  spec.add_development_dependency 'sqlite3'
-  spec.add_development_dependency 'byebug'
+  spec.add_development_dependency 'rubocop', '>= 1.17.0'
+  spec.add_development_dependency 'rubocop-rake'
+  spec.add_development_dependency 'rubocop-rspec'
   spec.add_development_dependency 'simplecov'
+  spec.add_development_dependency 'sqlite3'
 end

--- a/lib/feature_setting/orm/active_record/fs_feature.rb
+++ b/lib/feature_setting/orm/active_record/fs_feature.rb
@@ -4,7 +4,7 @@ module FeatureSetting
   class FsFeature < ActiveRecord::Base
     FEATURES = {
       test: false
-    }
+    }.freeze
 
     def features
       self.class::FEATURES
@@ -15,25 +15,25 @@ module FeatureSetting
     end
 
     class << self
-      def method_missing(m, *args)
+      def method_missing(_method, *_args)
         false
       end
 
-      def respond_to_missing?(*args)
+      def respond_to_missing?(*_args)
         true
       end
 
       def features
-        self.new.features
+        new.features
       end
 
       def klass
-        self.new.klass.to_s
+        new.klass.to_s
       end
 
-      def init_features!(remove_old_features = false)
+      def init_features!(remove_old_features: false)
         features.each do |key, value|
-          self.create_with(key: key, enabled: value, klass: klass).find_or_create_by(klass: klass, key: key)
+          create_feature(key, value)
           define_checker_method(key)
           define_enabler_method(key)
           define_disabler_method(key)
@@ -43,8 +43,8 @@ module FeatureSetting
 
       def cache_features!
         features.each do |key, value|
-          self.create_with(key: key, enabled: value, klass: klass).find_or_create_by(klass: klass, key: key)
-          value = self.where(key: key, klass: klass).first.enabled
+          create_feature(key, value)
+          value = find_by(key: key, klass: klass).enabled
           define_checker_method(key) { value }
           define_enabler_method(key) { false }
           define_disabler_method(key) { false }
@@ -52,48 +52,53 @@ module FeatureSetting
       end
 
       def define_checker_method(key, &block)
-        block = Proc.new do
-          record = self.where(key: key, klass: klass).first
-          record ? record.enabled : false
-        end unless block_given?
+        unless block_given?
+          block = proc do
+            record = find_by key: key, klass: klass
+            record ? record.enabled : false
+          end
+        end
         define_singleton_method("#{key}_enabled?") { block.call }
       end
 
       def define_enabler_method(key, &block)
-        block = Proc.new do
-          enable!(key)
-        end unless block_given?
+        unless block_given?
+          block = proc do
+            enable!(key)
+          end
+        end
         define_singleton_method("enable_#{key}!") { block.call }
       end
 
       def define_disabler_method(key, &block)
-        block = Proc.new do
-          disable!(key)
-        end unless block_given?
+        unless block_given?
+          block = proc do
+            disable!(key)
+          end
+        end
         define_singleton_method("disable_#{key}!") { block.call }
       end
 
       def remove_old_features!
-        self.where(key: all_stored_features - defined_features).destroy_all
+        where(key: all_stored_features - defined_features).destroy_all
       end
 
       def reset_features!
-        self.where(klass: klass).destroy_all
-        init_features!
+        init_features! if where(klass: klass).delete_all
       end
 
       def enable!(key)
-        if features.key?(key.to_sym)
-          record = self.where(key: key, klass: klass).first
-          record.update(enabled: true)
-        end
+        return unless features.key?(key.to_sym)
+
+        record = find_by key: key, klass: klass
+        record.update(enabled: true)
       end
 
       def disable!(key)
-        if features.key?(key.to_sym)
-          record = self.where(key: key, klass: klass).first
-          record.update(enabled: false)
-        end
+        return unless features.key?(key.to_sym)
+
+        record = find_by key: key, klass: klass
+        record.update(enabled: false)
       end
 
       def defined_features
@@ -103,7 +108,18 @@ module FeatureSetting
       private
 
       def all_stored_features
-        self.all.pluck(:key)
+        all.pluck(:key)
+      end
+
+      def create_feature(key, value)
+        create_with(
+          key: key,
+          enabled: value,
+          klass: klass
+        ).find_or_create_by(
+          klass: klass,
+          key: key
+        )
       end
     end
   end

--- a/lib/feature_setting/version.rb
+++ b/lib/feature_setting/version.rb
@@ -1,3 +1,3 @@
 module FeatureSetting
-  VERSION = "1.6.3"
+  VERSION = '1.6.4'.freeze
 end

--- a/lib/generators/feature_setting/install/install_generator.rb
+++ b/lib/generators/feature_setting/install/install_generator.rb
@@ -13,7 +13,7 @@ module FeatureSetting
       end
 
       desc 'Generates database tables for feature_settings'
-      source_root File.expand_path('../templates', __FILE__)
+      source_root File.expand_path('templates', __dir__)
 
       def create_migrations
         migration_name = 'create_fs_tables.rb'

--- a/lib/helpers/convert_value.rb
+++ b/lib/helpers/convert_value.rb
@@ -1,0 +1,37 @@
+module ConvertValue
+  class << self
+    # rubocop:disable Metrics/CyclomaticComplexity, Metrics/MethodLength
+    def convert_to_type(value, type)
+      case type
+      when 'String'
+        value.to_s
+      when 'TrueClass'
+        true
+      when 'NilClass', 'FalseClass'
+        false
+      when 'Fixnum', 'Integer'
+        value.to_i
+      when 'Float'
+        value.to_f
+      when 'Symbol'
+        value.to_sym
+      when 'Array'
+        value.split('|||')
+      when 'Hash'
+        Hashie::Mash.new(JSON.parse(value))
+      end
+    end
+    # rubocop:enable Metrics/CyclomaticComplexity, Metrics/MethodLength
+
+    def convert_to_string(value, type)
+      case type
+      when 'Hash', 'Hashie::Mash'
+        value.to_json
+      when 'Array'
+        value.join('|||')
+      else
+        value.to_s
+      end
+    end
+  end
+end

--- a/spec/feature_setting_spec.rb
+++ b/spec/feature_setting_spec.rb
@@ -4,8 +4,4 @@ describe FeatureSetting do
   it 'has a version number' do
     expect(FeatureSetting::VERSION).not_to be nil
   end
-
-  it 'does something useful' do
-    expect(true).to eq(true)
-  end
 end

--- a/spec/models/fs_feature_spec.rb
+++ b/spec/models/fs_feature_spec.rb
@@ -1,16 +1,14 @@
 require 'spec_helper'
 
 RSpec.describe FeatureSetting::FsFeature, type: :model do
-  class TestFeature < FeatureSetting::FsFeature
-    FEATURES = {
-      test: false,
-      authentication: true
-    }.freeze
-  end
+  subject(:fsf) { TestFeature }
 
-  # using identical FeatureSetting::Feature class
-  let(:fsf) do
-    TestFeature
+  before do
+    test_feature = Class.new(described_class)
+    features = { test: false, authentication: true }
+
+    stub_const('TestFeature', test_feature)
+    stub_const('TestFeature::FEATURES', features)
   end
 
   describe 'class methods' do
@@ -27,7 +25,7 @@ RSpec.describe FeatureSetting::FsFeature, type: :model do
 
     describe '.defined_features' do
       it 'returns an array of defined feature keys' do
-        expect(fsf.defined_features).to eq(%w(test authentication))
+        expect(fsf.defined_features).to eq(%w[test authentication])
       end
     end
 
@@ -48,79 +46,79 @@ RSpec.describe FeatureSetting::FsFeature, type: :model do
       end
 
       it 'creates checker methods' do
-        expect(fsf.test_enabled?).to eq(false)
-        expect(fsf.authentication_enabled?).to eq(true)
+        expect(fsf).not_to be_test_enabled
+        expect(fsf).to be_authentication_enabled
       end
 
       it 'caches stored values, ignoring any changes' do
         fsf.enable_test!
-        expect(fsf.test_enabled?).to be(false)
+        expect(fsf).not_to be_test_enabled
         fsf.disable_authentication!
-        expect(fsf.authentication_enabled?).to be(true)
+        expect(fsf).to be_authentication_enabled
       end
     end
 
     describe '.remove_old_features!' do
       it 'destroys old features in database but not defined anymore' do
         fsf.create!(key: 'new', enabled: true, klass: 'FeatureSetting::FsFeature')
-        expect { fsf.remove_old_features! }.to change { fsf.count }.from(3).to(2)
+        expect { fsf.remove_old_features! }.to change(fsf, :count).from(3).to(2)
       end
     end
 
     describe '.reset_features!' do
-      let(:all_features) { double(:all_features) }
-      it 'should destroy the records for this klass' do
-        allow(fsf).to receive(:init_features!)
-        expect(all_features).to receive(:destroy_all).and_return true
-        expect(fsf).to receive(:where).and_return all_features
-        fsf.reset_features!
+      it 'creates a new set of features on completion' do
+        features = { authentication: true }
+
+        stub_const('TestFeature::FEATURES', features)
+
+        expect { fsf.reset_features! }.to change(fsf, :count).from(2).to(1)
       end
     end
 
     describe '.key_enabled?' do
       it 'creates enabled? methods' do
-        expect(fsf.test_enabled?).to be_falsey
+        expect(fsf).not_to be_test_enabled
       end
 
       it 'returns false when feature is deleted after initialization' do
         fsf.enable_test!
-        expect(fsf.test_enabled?).to be_truthy
+        expect(fsf).to be_test_enabled
         fsf.where(key: 'test').first.destroy
-        expect(fsf.test_enabled?).to be_falsey
+        expect(fsf).not_to be_test_enabled
       end
     end
 
     describe '.enable!' do
       it 'enables a feature' do
-        expect(fsf.test_enabled?).to be_falsey
+        expect(fsf).not_to be_test_enabled
         fsf.enable!(:test)
-        expect(fsf.test_enabled?).to be_truthy
+        expect(fsf).to be_test_enabled
       end
 
       it 'works with symbols or strings' do
         fsf.enable! 'test'
-        expect(fsf.test_enabled?).to be_truthy
+        expect(fsf).to be_test_enabled
       end
 
       it 'works when using custom method' do
         fsf.enable_test!
-        expect(fsf.test_enabled?).to be_truthy
+        expect(fsf).to be_test_enabled
         fsf.disable_test!
-        expect(fsf.test_enabled?).to be_falsey
+        expect(fsf).not_to be_test_enabled
       end
     end
 
     describe '.disable!' do
       it 'disables a feature' do
         fsf.enable!(:test)
-        expect(fsf.test_enabled?).to be_truthy
+        expect(fsf).to be_test_enabled
         fsf.disable!(:test)
-        expect(fsf.test_enabled?).to be_falsey
+        expect(fsf).not_to be_test_enabled
       end
 
       it 'works with symbols or strings' do
         fsf.disable! 'test'
-        expect(fsf.test_enabled?).to be_falsey
+        expect(fsf).not_to be_test_enabled
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,19 +1,19 @@
 require 'simplecov'
 SimpleCov.start
 require 'bundler/setup'
-#require 'codeclimate-test-reporter'
-#CodeClimate::TestReporter.start
+# require 'codeclimate-test-reporter'
+# CodeClimate::TestReporter.start
 Bundler.setup
-$LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
+$LOAD_PATH.unshift File.expand_path('../lib', __dir__)
 
 require 'feature_setting'
 require 'hashie'
-require 'generators/feature_setting/install/templates/migrations/create_fs_tables.rb'
+require 'generators/feature_setting/install/templates/migrations/create_fs_tables'
 
 ActiveRecord::Base.establish_connection(
   adapter: 'sqlite3',
   database: ':memory:'
 )
-ActiveRecord::Base.logger = Logger.new(STDOUT)
+ActiveRecord::Base.logger = Logger.new($stdout)
 ActiveRecord::Base.logger.level = :warn
 CreateFsTables.up


### PR DESCRIPTION
Hi everyone,

This PR:
- adds `rubocop` and its config based on the current state of the codebase
- removes redundant `self`
- adds HEREDOC description to the gemspec
- moves feature/setting creating logic to its own respective methods to
  slim down bloated methods and increase readability
- replaces `where(key: key, klass: klass).first` with `find_by()` to
  eliminate redundant `ORDER_BY` since it is using `.take()` instead of
  `.first()`
- replaces `destroy_all` with `delete_all`: we don't have any
  associations that needs to be destroyed alongside. Additionally,
  `delete_all` is much faster since it is just a single `DELETE`
  statement, whereas `destroy_all` calls `each(&:destroy)` producing
  number-of-records statements.
- creates a new `helpers` directory with `ConvertValue` helper in order
  to move common logic to a single source.
- fixes the global namespace pollution caused by defining test classes
  in specs: when defined in a spec, a class exists globally which is a
  problem at least if you will try to define a class with the same
  name in another spec ;) A solution to this is to define an anonymous
  class and bind it to a stubbed constant so both only exist during the
  example.
- fixes `reset_features!` and `reset_settings!` methods along with
  respective specs. There were several problems:
  + the specs were written to check if this functionality destroys the
    data, however, the method actually creates a new set of
    features/settings on completion, therefore, it makes sense to check
    if new dataset was created.
  + in the abovementioned methods we're triggering `init_*!`
    independently from the old data deletion without checking if
    deletion was a success or not.
- fixes `existing_key(key, hash)` method and its spec. The method has
  been written in a way that calling `existing_key('non-existent-key')`
  returns `:non-existent-key`. In other words, `||` operator returns a
  boolean even if one of the methods there throws an error, so this adds
  a `return unless` in order to return early from the method if a key
  doesn't exist.
- adds custom errors to `FeatureSetting`